### PR TITLE
[#62] Foundry V13 Upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `module.json`: Foundry manifest (id `playerStatus`), versioning, deps.
+- `scripts/`: ES modules loaded by Foundry (`playerstatus.js`, `afkStatus.mjs`, `writtingStatus.mjs`).
+- `languages/`: i18n resources (`en.json`, `de.json`, `fr.json`).
+- `img/`: module assets (e.g., `afk_icon.webp`).
+- `.github/`: CI and release automation (if any).
+
+## Build, Test, and Development Commands
+- Build: none. Code ships as plain ES modules referenced in `module.json`.
+- Run locally: symlink or copy this folder into your Foundry `Data/modules/playerStatus`, then start Foundry and enable the module.
+  - Example (Linux/macOS): `ln -s $(pwd) ~/FoundryVTT/Data/modules/playerStatus`
+- Packaging: bump `version` in `module.json` and create a zip of the repo root for release. Ensure `manifest` and `download` URLs point to the new tag.
+
+## Coding Style & Naming Conventions
+- JavaScript (ESM): use `const`/`let`, trailing semicolons, 4‑space indent.
+- File/class naming: PascalCase classes (`AfkStatus`, `WrittingStatus`), kebab/flat file names as in `scripts/`.
+- Settings and keys: keep `static moduleName = "playerStatus"` and existing key names (`afk`, `typing`).
+- Localization: add keys to all files in `languages/`. Prefer concise keys like `PLAYER-STATUS.afk.*`.
+
+## Testing Guidelines
+- Manual verification in Foundry VTT (compat: min 10, verified 12.331).
+  - Enable dependency `playerListStatus` (required in `module.json`).
+  - Validate: AFK toggle button, `/afk [reason]` and `/back` chat commands, typing indicator timeout and icon position.
+- No automated tests in repo; keep changes small and test across GM/player users.
+
+## Commit & Pull Request Guidelines
+- Commits: short imperative subject; reference issues/PRs when relevant (e.g., `[#59] Verify for 12.331`).
+- PRs: include summary, linked issue, steps to reproduce/verify, and screenshots/GIFs of UI changes (player list icons, chat behavior).
+- Versioning: update `module.json` version and compatibility fields as part of release PRs.
+- Internationalization: update all `languages/*.json` and note additions in PR description.
+
+## Security & Configuration Tips
+- Avoid direct DOM selectors outside Foundry elements used here (e.g., `#chat-message`).
+- Respect user/world scope for settings; default to non‑destructive behavior.

--- a/module.json
+++ b/module.json
@@ -26,7 +26,7 @@
 	"compatibility": {
 		"minimum": "10",
 		"verified": "12.331",
-		"maximum": "12"
+		"maximum": "13"
 	},
 	"languages": [
 		{

--- a/scripts/afkStatus.mjs
+++ b/scripts/afkStatus.mjs
@@ -28,8 +28,14 @@ export default class AfkStatus {
                 let chatData = {
                     content: game.i18n.format("PLAYER-STATUS.afk.back", {
                         name: game.user.name
-                    }), type: CONST.CHAT_MESSAGE_TYPES.OOC
+                    })
                 };
+                const FC = foundry?.CONST;
+                if (FC?.CHAT_MESSAGE_STYLES?.OOC != null) {
+                    chatData.style = FC.CHAT_MESSAGE_STYLES.OOC;
+                } else {
+                    chatData.type = CONST.CHAT_MESSAGE_TYPES.OOC;
+                }
                 ChatMessage.create(chatData);
             }
             if (game.settings.get(AfkStatus.moduleName, "showAfkIndicator")) {
@@ -41,8 +47,14 @@ export default class AfkStatus {
                 let chatData = {
                     content: game.i18n.format("PLAYER-STATUS.afk.afk", {
                         name: game.user.name
-                    }) + (typeof reason !== 'undefined' ? "<br/>" + reason : ""), type: CONST.CHAT_MESSAGE_TYPES.OOC
+                    }) + (typeof reason !== 'undefined' ? "<br/>" + reason : "")
                 };
+                const FC = foundry?.CONST;
+                if (FC?.CHAT_MESSAGE_STYLES?.OOC != null) {
+                    chatData.style = FC.CHAT_MESSAGE_STYLES.OOC;
+                } else {
+                    chatData.type = CONST.CHAT_MESSAGE_TYPES.OOC;
+                }
                 ChatMessage.create(chatData);
             }
             if (game.settings.get(AfkStatus.moduleName, "showAfkIndicator")) {

--- a/scripts/playerstatus.js
+++ b/scripts/playerstatus.js
@@ -3,6 +3,21 @@
 import AfkStatus from "./afkStatus.mjs";
 import WrittingStatus from "./writtingStatus.mjs";
 
+// Suppress deprecated global access warnings by mapping Game -> foundry.Game in V13+
+Hooks.once('init', () => {
+    try {
+        if (globalThis?.foundry?.Game) {
+            Object.defineProperty(globalThis, 'Game', {
+                configurable: true,
+                enumerable: false,
+                get() { return foundry.Game; }
+            });
+        }
+    } catch (e) {
+        // ignore if property is non-configurable or environment differs
+    }
+});
+
 
 Hooks.once('playerListStatusInit', function (register) {
     game.settings.register(AfkStatus.moduleName, "showAfkIndicator", {
@@ -107,16 +122,26 @@ Hooks.once('playerListStatusInit', function (register) {
         }
 
         if (register.registerKey(AfkStatus.keyName, "💤", options)) {
-            Hooks.on("getSceneControlButtons", function (controls) {
-                let tileControls = controls.find(x => x.name === "token");
-                // noinspection JSUnusedGlobalSymbols
-                tileControls.tools.push({
-                    icon: "fas fa-comment-slash",
-                    name: "afk",
-                    title: "💤AFK",
-                    button: true,
-                    onClick: () => game.afkStatus.afk()
-                });
+            Hooks.on("getSceneControlButtons", controls => {
+                if (parseInt(game.version) >= 13) {
+                    controls.tokens.tools.afk = {
+                        name: "afk",
+                        title: "💤AFK",
+                        icon: "fas fa-comment-slash",
+                        button: true,
+                        onChange: () => game.afkStatus.afk()
+                    };
+                } else {
+                    let tileControls = controls.find(x => x.name === "token");
+                    // noinspection JSUnusedGlobalSymbols
+                    tileControls.tools.push({
+                        icon: "fas fa-comment-slash",
+                        name: "afk",
+                        title: "💤AFK",
+                        button: true,
+                        onClick: () => game.afkStatus.afk()
+                    });
+                }
             });
         }
     }
@@ -134,7 +159,8 @@ Hooks.once('playerListStatusInit', function (register) {
 
 Hooks.once('playerListStatusReady', function (playerListStatus) {
     if (playerListStatus.isRegistered(AfkStatus.keyName)) {
-        Game.prototype.afkStatus = new AfkStatus();
+        // Avoid deprecated global Game; attach to the game instance
+        game.afkStatus = new AfkStatus();
         game.chatCommands?.register({
             name: "/afk",
             module: "PlayerStatus",
@@ -149,6 +175,7 @@ Hooks.once('playerListStatusReady', function (playerListStatus) {
         });
     }
     if (playerListStatus.isRegistered(WrittingStatus.keyName)) {
-        Game.prototype.writtingStatus = new WrittingStatus();
+        // Avoid deprecated global Game; attach to the game instance
+        game.writtingStatus = new WrittingStatus();
     }
 });


### PR DESCRIPTION
- Scene controls (v13): replace undefined d(...) wrapper; use onChange for the “💤AFK” tool (removes onClick deprecation). v12 path retains onClick.
- Game API: stop using global Game.prototype; attach instances to game.*. Add a safe init-time shim mapping Game → foundry.Game to suppress dependency warnings (e.g., playerListStatus) on v13+.
- Chat messages: switch to ChatMessage.style with CONST.CHAT_MESSAGE_STYLES.OOC; fallback to type/CHAT_MESSAGE_TYPES.OOC on older cores (v10/11).
- CONST usage: prefer foundry.CONST when available to avoid deprecations.
- Docs: add AGENTS.md contributor guide (project structure, dev workflow, testing, PRs).

Fixes: #62