### PR TITLE
[#68] Foundry V14 Upgrade

### DIFF
--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
 			"url": "https://github.com/Talaren"
 		}
 	],
-	"version": "3.1.3",
+	"version": "5.0.0",
 	"relationships": {
 		"requires": [
 			{
@@ -17,16 +17,16 @@
 				"type": "module",
 				"manifest": "https://github.com/Talaren/FoundryVTT-PlayerListStatus/releases/latest/download/module.json",
 				"compatibility": {
-					"minimum": "4.0.0",
-					"verified": "4.0.0"
+					"minimum": "5.0.0",
+					"verified": "5.0.0"
 				}
 			}
 		]
 	},
 	"compatibility": {
 		"minimum": "10",
-		"verified": "13.348",
-		"maximum": "13"
+		"verified": "14.359",
+		"maximum": "14"
 	},
 	"languages": [
 		{
@@ -49,5 +49,5 @@
 		"scripts/playerstatus.js"
 	],
 	"manifest": "https://github.com/Talaren/FoundryVTT-PlayerStatus/releases/latest/download/module.json",
-	"download": "https://github.com/Talaren/FoundryVTT-PlayerStatus/releases/download/3.1.3/module.zip"
+	"download": "https://github.com/Talaren/FoundryVTT-PlayerStatus/releases/download/5.0.0/module.zip"
 }


### PR DESCRIPTION
Bumped module version from 3.1.3 to 5.0.0.
Updated required dependency (playerListStatus) compatibility from 4.0.0 to 5.0.0.
Updated Foundry compatibility metadata to verified: 14.359 and maximum: 14, and updated the release download URL to 5.0.0.